### PR TITLE
Clean configuration & use of logging throughout the code

### DIFF
--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -70,11 +70,8 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	found, err := r.S3Client.BucketExists(bucketResource.Spec.Name)
 	if err != nil {
 		logger.Error(err, "an error occurred while checking the existence of a bucket", "bucket", bucketResource.Spec.Name)
-		// TODO ? : logging in this way gets the error from S3Client, but not the one from r.Status().Update()
-		// (this applies to every occurrence of SetBucketStatusCondition down below)
-		SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketExistenceCheckFailed",
-			fmt.Sprintf("Checking existence of bucket [%s] from S3 instance has failed", bucketResource.Spec.Name))
-		return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+		return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketExistenceCheckFailed",
+			fmt.Sprintf("Checking existence of bucket [%s] from S3 instance has failed", bucketResource.Spec.Name), err)
 	}
 
 	// If the bucket does not exist, it is created based on the CR (with potential quotas and paths)
@@ -84,18 +81,16 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		err = r.S3Client.CreateBucket(bucketResource.Spec.Name)
 		if err != nil {
 			logger.Error(err, "an error occurred while creating a bucket", "bucket", bucketResource.Spec.Name)
-			SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketCreationFailed",
-				fmt.Sprintf("Creation of bucket [%s] on S3 instance has failed", bucketResource.Spec.Name))
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketCreationFailed",
+				fmt.Sprintf("Creation of bucket [%s] on S3 instance has failed", bucketResource.Spec.Name), err)
 		}
 
 		// Setting quotas
 		err = r.S3Client.SetQuota(bucketResource.Spec.Name, bucketResource.Spec.Quota.Default)
 		if err != nil {
 			logger.Error(err, "an error occurred while setting a quota on a bucket", "bucket", bucketResource.Spec.Name, "quota", bucketResource.Spec.Quota.Default)
-			SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "SetQuotaOnBucketFailed",
-				fmt.Sprintf("Setting a quota of [%v] on bucket [%s] has failed", bucketResource.Spec.Quota.Default, bucketResource.Spec.Name))
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "SetQuotaOnBucketFailed",
+				fmt.Sprintf("Setting a quota of [%v] on bucket [%s] has failed", bucketResource.Spec.Quota.Default, bucketResource.Spec.Name), err)
 		}
 
 		// Création des chemins
@@ -103,20 +98,14 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			err = r.S3Client.CreatePath(bucketResource.Spec.Name, v)
 			if err != nil {
 				logger.Error(err, "an error occurred while creating a path on a bucket", "bucket", bucketResource.Spec.Name, "path", v)
-				SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "CreatingPathOnBucketFailed",
-					fmt.Sprintf("Creating the path [%s] on bucket [%s] has failed", v, bucketResource.Spec.Name))
-				return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+				return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "CreatingPathOnBucketFailed",
+					fmt.Sprintf("Creating the path [%s] on bucket [%s] has failed", v, bucketResource.Spec.Name), err)
 			}
 		}
 
 		// The bucket creation, quota setting and path creation happened without any error
-		SetBucketStatusCondition(bucketResource, "OperatorSucceeded", metav1.ConditionTrue, "BucketCreated",
-			fmt.Sprintf("The bucket [%s] was created with its quota and paths", bucketResource.Spec.Name))
-		if err := r.Status().Update(ctx, bucketResource); err != nil {
-			logger.Error(err, "an error occurred while updating the status of a bucket", "bucket", bucketResource.Spec.Name)
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
+		return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorSucceeded", metav1.ConditionTrue, "BucketCreated",
+			fmt.Sprintf("The bucket [%s] was created with its quota and paths", bucketResource.Spec.Name), nil)
 	}
 
 	// If the bucket exists on the S3 server, then we need to compare it to
@@ -126,9 +115,8 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	effectiveQuota, err := r.S3Client.GetQuota(bucketResource.Spec.Name)
 	if err != nil {
 		logger.Error(err, "an error occurred while getting the quota for a bucket", "bucket", bucketResource.Spec.Name)
-		SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketQuotaCheckFailed",
-			fmt.Sprintf("The check for a quota on bucket [%s] has failed", bucketResource.Spec.Name))
-		return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+		return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketQuotaCheckFailed",
+			fmt.Sprintf("The check for a quota on bucket [%s] has failed", bucketResource.Spec.Name), err)
 	}
 
 	// If a quota exists, we check it versus the spec of the CR. In case they don't match,
@@ -144,9 +132,8 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		err = r.S3Client.SetQuota(bucketResource.Spec.Name, quotaToResetTo)
 		if err != nil {
 			logger.Error(err, "an error occurred while resetting the quota for a bucket", "bucket", bucketResource.Spec.Name, "quotaToResetTo", quotaToResetTo)
-			SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketQuotaUpdateFailed",
-				fmt.Sprintf("The quota update (%v => %v) on bucket [%s] has failed", effectiveQuota, quotaToResetTo, bucketResource.Spec.Name))
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketQuotaUpdateFailed",
+				fmt.Sprintf("The quota update (%v => %v) on bucket [%s] has failed", effectiveQuota, quotaToResetTo, bucketResource.Spec.Name), err)
 		}
 	}
 
@@ -161,30 +148,24 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		pathExists, err := r.S3Client.PathExists(bucketResource.Spec.Name, pathInCr)
 		if err != nil {
 			logger.Error(err, "an error occurred while checking a path's existence on a bucket", "bucket", bucketResource.Spec.Name, "path", pathInCr)
-			SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketPathCheckFailed",
-				fmt.Sprintf("The check for path [%s] on bucket [%s] has failed", pathInCr, bucketResource.Spec.Name))
-			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketPathCheckFailed",
+				fmt.Sprintf("The check for path [%s] on bucket [%s] has failed", pathInCr, bucketResource.Spec.Name), err)
 		}
 
 		if !pathExists {
 			err = r.S3Client.CreatePath(bucketResource.Spec.Name, pathInCr)
 			if err != nil {
 				logger.Error(err, "an error occurred while creating a path on a bucket", "bucket", bucketResource.Spec.Name, "path", pathInCr)
-				SetBucketStatusCondition(bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketPathCreationFailed",
-					fmt.Sprintf("The creation of path [%s] on bucket [%s] has failed", pathInCr, bucketResource.Spec.Name))
-				return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, bucketResource)})
+				return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketPathCreationFailed",
+					fmt.Sprintf("The creation of path [%s] on bucket [%s] has failed", pathInCr, bucketResource.Spec.Name), err)
 			}
 		}
 	}
 
 	// The bucket reconciliation with its CR was succesful (or NOOP)
-	SetBucketStatusCondition(bucketResource, "OperatorSucceeded", metav1.ConditionTrue, "BucketUpdated",
-		fmt.Sprintf("The bucket [%s] was updated according to its matching custom resource", bucketResource.Spec.Name))
-	if err := r.Status().Update(ctx, bucketResource); err != nil {
-		logger.Error(err, "an error occurred while updating the status of a bucket", "bucket", bucketResource.Spec.Name)
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{}, nil
+	return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorSucceeded", metav1.ConditionTrue, "BucketUpdated",
+		fmt.Sprintf("The bucket [%s] was updated according to its matching custom resource", bucketResource.Spec.Name), nil)
+
 }
 
 // SetupWithManager sets up the controller with the Manager.*
@@ -207,7 +188,9 @@ func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func SetBucketStatusCondition(bucketResource *s3v1alpha1.Bucket, conditionType string, status metav1.ConditionStatus, reason string, message string) {
+func (r *BucketReconciler) SetBucketStatusConditionAndUpdate(ctx context.Context, bucketResource *s3v1alpha1.Bucket, conditionType string, status metav1.ConditionStatus, reason string, message string, srcError error) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
 	meta.SetStatusCondition(&bucketResource.Status.Conditions,
 		metav1.Condition{
 			Type:               conditionType,
@@ -217,4 +200,11 @@ func SetBucketStatusCondition(bucketResource *s3v1alpha1.Bucket, conditionType s
 			Message:            message,
 			ObservedGeneration: bucketResource.GetGeneration(),
 		})
+
+	err := r.Status().Update(ctx, bucketResource)
+	if err != nil {
+		logger.Error(err, "an error occurred while updating the status of the bucket resource")
+		return ctrl.Result{}, utilerrors.NewAggregate([]error{err, srcError})
+	}
+	return ctrl.Result{}, srcError
 }

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -51,7 +51,6 @@ type PolicyReconciler struct {
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=policies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=policies/finalizers,verbs=update
 
-
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 //
@@ -60,14 +59,11 @@ type PolicyReconciler struct {
 func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// TODO ? : refactor to better organize code depending on the event received
-	// (eg : create methods "HandleCreateEvent", "HandleUpdateEvent", ...)
-
 	policyResource := &s3v1alpha1.Policy{}
 	err := r.Get(ctx, req.NamespacedName, policyResource)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			logger.Info(fmt.Sprintf("Policy CRD %s has been removed. NOOP.", req.Name))
+			logger.Info("The Policy CRD has been removed ; as such the Policy controller is NOOP.", "req.Name", req.Name)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -78,8 +74,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// If the policy does not exist on S3...
 	if err != nil {
-		log.Log.Error(err, err.Error())
-		// TODO ? : logging in this way gets the error from S3Client, but not the one form r.Status().Update()
+		logger.Error(err, "an error occurred while checking the existence of a policy", "policy", policyResource.Spec.Name)
+		// TODO ? : logging in this way gets the error from S3Client, but not the one from r.Status().Update()
 		// (this applies to every occurrence of SetBucketStatusCondition down below)
 		SetPolicyStatusCondition(policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyInfoFailed",
 			fmt.Sprintf("Obtaining policy[%s] info from S3 instance has failed", policyResource.Spec.Name))
@@ -87,22 +83,21 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if effectivePolicy == nil {
-		log.Log.Info(fmt.Sprintf("Policy %s does not exist and will be created", policyResource.Spec.Name))
 
 		// Policy creation using info from the CR
 		err = r.S3Client.CreateOrUpdatePolicy(policyResource.Spec.Name, policyResource.Spec.PolicyContent)
 		if err != nil {
-			log.Log.Error(err, err.Error())
+			logger.Error(err, "an error occurred while creating the policy", "policy", policyResource.Spec.Name)
 			SetPolicyStatusCondition(policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyCreationFailed",
 				fmt.Sprintf("The creation of policy [%s] has failed", policyResource.Spec.Name))
 			return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, policyResource)})
-			// return ctrl.Result{}, fmt.Errorf("can't create policy " + policyResource.Spec.Name)
 		}
 
 		// Update status to reflect policy creation
 		SetPolicyStatusCondition(policyResource, "OperatorSucceeded", metav1.ConditionTrue, "PolicyCreated",
 			fmt.Sprintf("The creation of policy [%s] has succeeded", policyResource.Spec.Name))
 		if err := r.Status().Update(ctx, policyResource); err != nil {
+			logger.Error(err, "an error occurred while updating the status after creating the policy", "policy", policyResource.Spec.Name)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -112,11 +107,10 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// If the policy exists on S3, we compare its state to the custom resource that spawned it on K8S
 	matching, err := IsPolicyMatchingWithCustomResource(policyResource, effectivePolicy)
 	if err != nil {
-		log.Log.Error(err, err.Error())
+		logger.Error(err, "an error occurred while comparing actual and expected configuration for the policy", "policy", policyResource.Spec.Name)
 		SetPolicyStatusCondition(policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyComparisonFailed",
 			fmt.Sprintf("The comparison between the effective policy [%s] on S3 and its corresponding custom resource on K8S has failed", policyResource.Spec.Name))
 		return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, policyResource)})
-		// return ctrl.Result{}, fmt.Errorf("can't check if policy %s matches with the custom resource ", policyResource.Spec.Name)
 	}
 	// If the two match, no reconciliation is needed, but we still need to update
 	// the status, in case the generation changed (eg : rollback to previous state after a problematic change)
@@ -124,6 +118,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		SetPolicyStatusCondition(policyResource, "OperatorSucceeded", metav1.ConditionTrue, "PolicyUnchanged",
 			fmt.Sprintf("The policy [%s] matches its corresponding custom resource", policyResource.Spec.Name))
 		if err := r.Status().Update(ctx, policyResource); err != nil {
+			logger.Error(err, "an error occurred while updating the status after comparing the actual and expected configuration for the policy", "policy", policyResource.Spec.Name)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -131,17 +126,17 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// If not we update the policy to match the CR
 	err = r.S3Client.CreateOrUpdatePolicy(policyResource.Spec.Name, policyResource.Spec.PolicyContent)
 	if err != nil {
-		log.Log.Error(err, err.Error())
+		logger.Error(err, "an error occurred while updating the policy", "policy", policyResource.Spec.Name)
 		SetPolicyStatusCondition(policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyUpdateFailed",
 			fmt.Sprintf("The update of effective policy [%s] on S3 to match its corresponding custom resource on K8S has failed", policyResource.Spec.Name))
 		return ctrl.Result{}, utilerrors.NewAggregate([]error{err, r.Status().Update(ctx, policyResource)})
-		// return ctrl.Result{}, fmt.Errorf("can't recreate policy " + policyResource.Spec.Name)
 	}
 
 	// Update status to reflect policy update
 	SetPolicyStatusCondition(policyResource, "OperatorSucceeded", metav1.ConditionTrue, "PolicyUpdated",
 		fmt.Sprintf("The policy [%s] was updated according to its matching custom resource", policyResource.Spec.Name))
 	if err := r.Status().Update(ctx, policyResource); err != nil {
+		logger.Error(err, "an error occurred while updating the status after updating the policy", "policy", policyResource.Spec.Name)
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
@@ -178,7 +173,7 @@ func IsPolicyMatchingWithCustomResource(policyResource *s3v1alpha1.Policy, effec
 	}
 
 	// Another gotcha is that the effective policy comes up as a json.RawContent,
-	// which need marshalling in order to be properly compared to the []byte we get from the CR.
+	// which needs marshalling in order to be properly compared to the []byte we get from the CR.
 	marshalled, err := json.Marshal(effectivePolicy.Policy)
 	if err != nil {
 		return false, err

--- a/controllers/s3/factory/interface.go
+++ b/controllers/s3/factory/interface.go
@@ -4,14 +4,20 @@ import (
 	"fmt"
 
 	"github.com/minio/madmin-go/v2"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	s3Logger = ctrl.Log.WithName("s3Client")
 )
 
 type S3Client interface {
 	BucketExists(name string) (bool, error)
 	CreateBucket(name string) error
 	DeleteBucket(name string) error
-	CreatePath(bucketname string, name string) error
-	PathExists(bucketname string, name string) (bool, error)
+	CreatePath(bucketname string, path string) error
+	PathExists(bucketname string, path string) (bool, error)
 	GetQuota(name string) (int64, error)
 	SetQuota(name string, quota int64) error
 	// see comment in [minioS3Client.go] regarding the absence of a PolicyExists method

--- a/controllers/s3/factory/minioS3Client.go
+++ b/controllers/s3/factory/minioS3Client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -125,8 +124,8 @@ func (minioS3Client *MinioS3Client) CreatePath(bucketname string, path string) e
 	emptyReader := bytes.NewReader([]byte(""))
 	_, err := minioS3Client.client.PutObject(context.Background(), bucketname, "/"+path+"/"+".keep", emptyReader, 0, minio.PutObjectOptions{})
 	if err != nil {
-		fmt.Println(err)
-		return fmt.Errorf("error on path creation" + bucketname + " " + path)
+		s3Logger.Error(err, "an error occurred during path creation on bucket", "bucket", bucketname, "path", path)
+		return err
 	}
 	return nil
 }
@@ -211,6 +210,6 @@ func (minioS3Client *MinioS3Client) GetPolicyInfo(name string) (*madmin.PolicyIn
 // The AddCannedPolicy of the madmin client actually does both creation and update (so does the CLI, as both
 // are wired to the same endpoint on Minio API server).
 func (minioS3Client *MinioS3Client) CreateOrUpdatePolicy(name string, content string) error {
-	s3Logger.Info("create or update policy", "policy", name, "policyContent", content)
+	s3Logger.Info("create or update policy", "policy", name)
 	return minioS3Client.adminClient.AddCannedPolicy(context.Background(), name, []byte(content))
 }

--- a/controllers/s3/factory/minioS3Client.go
+++ b/controllers/s3/factory/minioS3Client.go
@@ -110,12 +110,12 @@ func (minioS3Client *MinioS3Client) BucketExists(name string) (bool, error) {
 }
 
 func (minioS3Client *MinioS3Client) CreateBucket(name string) error {
-	s3Logger.Info("checking a bucket", "bucket", name)
+	s3Logger.Info("creating bucket", "bucket", name)
 	return minioS3Client.client.MakeBucket(context.Background(), name, minio.MakeBucketOptions{Region: minioS3Client.s3Config.Region})
 }
 
 func (minioS3Client *MinioS3Client) DeleteBucket(name string) error {
-	s3Logger.Info("deleting a bucket", "bucket", name)
+	s3Logger.Info("deleting bucket", "bucket", name)
 	return minioS3Client.client.RemoveBucket(context.Background(), name)
 }
 

--- a/controllers/s3/factory/mockedS3Client.go
+++ b/controllers/s3/factory/mockedS3Client.go
@@ -1,56 +1,53 @@
 package factory
 
 import (
-	"fmt"
-	"log"
-
 	"github.com/minio/madmin-go/v2"
 )
 
 type MockedS3Client struct{}
 
 func (mockedS3Provider *MockedS3Client) BucketExists(name string) (bool, error) {
-	log.Println("check if bucket " + name + "exists")
+	s3Logger.Info("checking bucket existence", "bucket", name)
 	return false, nil
 }
 
 func (mockedS3Provider *MockedS3Client) CreateBucket(name string) error {
-	log.Println("create bucket " + name + "exists")
+	s3Logger.Info("checking a bucket", "bucket", name)
 	return nil
-}
-
-func (mockedS3Provider *MockedS3Client) CreatePath(bucketname string, name string) error {
-	log.Println("create path " + name + "exists")
-	return nil
-}
-
-func (mockedS3Provider *MockedS3Client) PathExists(bucketname string, name string) (bool, error) {
-	log.Println("check if  path " + name + "exists")
-	return true, nil
 }
 
 func (mockedS3Provider *MockedS3Client) DeleteBucket(name string) error {
-	log.Println("delete bucket " + name + "exists")
+	s3Logger.Info("deleting a bucket", "bucket", name)
 	return nil
 }
 
+func (mockedS3Provider *MockedS3Client) CreatePath(bucketname string, path string) error {
+	s3Logger.Info("creating a path on a bucket", "bucket", bucketname, "path", path)
+	return nil
+}
+
+func (mockedS3Provider *MockedS3Client) PathExists(bucketname string, path string) (bool, error) {
+	s3Logger.Info("checking path existence on a bucket", "bucket", bucketname, "path", path)
+	return true, nil
+}
+
 func (mockedS3Provider *MockedS3Client) GetQuota(name string) (int64, error) {
-	log.Println("bucket " + name + " get quota")
+	s3Logger.Info("getting quota on bucket", "bucket", name)
 	return 1, nil
 }
 
 func (mockedS3Provider *MockedS3Client) SetQuota(name string, quota int64) error {
-	log.Println("set quota " + fmt.Sprint(quota) + "on bucket " + name + "exists")
+	s3Logger.Info("setting quota on bucket", "bucket", name, "quotaToSet", quota)
 	return nil
 }
 
 func (mockedS3Provider *MockedS3Client) GetPolicyInfo(name string) (*madmin.PolicyInfo, error) {
-	log.Println("create policy " + name)
+	s3Logger.Info("retrieving policy info", "policy", name)
 	return nil, nil
 }
 
 func (mockedS3Provider *MockedS3Client) CreateOrUpdatePolicy(name string, content string) error {
-	log.Println("create policy " + name)
+	s3Logger.Info("create or update policy", "policy", name, "policyContent", content)
 	return nil
 }
 


### PR DESCRIPTION
The initial implementation of the operator used contributions from various people, which led to having various different ways of logging. Some examples below, although out of context they are not particularly useful : 

- `log.Log.Error(err, err.Error())`
- `logger.Info(fmt.Sprintf("***"))`
- `log.Fatalln(err)`
- `log.Println("***")`
- `logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))`

This issue aims at cleaning this up, mostly by enforcing the use of logr, [as documented on the Operator SDK website](https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/).

Optionally, there's another potential problem with the logs of the two controllers (bucket and policy). There is a fair number of calls to `r.Status().Update(ctx, xxxResource)`, and for most of them the code does not accomodate to errors that might occur. While testing for errors is not a technical problem, doing so naively would lower the readability of the code. If a decent proposition to refactor this exists, it could definitely enter the scope of this PR.