### PR TITLE
build Docker image for ARM64 #32 (in addition to x86_64)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,5 +34,6 @@ jobs:
             ${{ steps.docker_meta.outputs.tags }}
             ${{ github.ref == 'refs/heads/main' && 'inseefrlab/s3-operator:latest' || '' }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Build docker immage for ARM64 (this is the arch of Apple Sillicon)