### PR TITLE
Manage resource deletion and event filtering, fix imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+.vscode

--- a/PROJECT
+++ b/PROJECT
@@ -9,7 +9,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: s3-operator
-repo: github.com/phlg/s3-operator-downgrade
+repo: github.com/InseeFrLab/s3-operator
 resources:
 - api:
     crdVersion: v1
@@ -18,7 +18,7 @@ resources:
   domain: onyxia.sh
   group: s3.onyxia.sh
   kind: Bucket
-  path: github.com/phlg/s3-operator-downgrade/api/v1alpha1
+  path: github.com/InseeFrLab/s3-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -27,7 +27,7 @@ resources:
   domain: onyxia.sh
   group: s3.onyxia.sh
   kind: Policy
-  path: github.com/phlg/s3-operator-downgrade/api/v1alpha1
+  path: github.com/InseeFrLab/s3-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -36,6 +36,6 @@ resources:
   domain: onyxia.sh
   group: s3.onyxia.sh
   kind: Path
-  path: github.com/phlg/s3-operator-downgrade/api/v1alpha1
+  path: github.com/InseeFrLab/s3-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ The parameters are summarized in the table below :
 | `s3-endpoint-url`               | `localhost:9000` | -                    | no  | Hostname (or hostname:port) of the S3 server.
 | `s3-provider`                   | `minio`          | -                    | no  | S3 provider (possible values : `minio`, `mockedS3Provider`)
 | `s3-secret-key`                 | -                | `S3_SECRET_KEY`      | no  | The secret key used to interact with  the S3 server.
-| `useSsl`                        | `true`           | -                    | no  | Use of SSL/TLS to connect to the S3 server
+| `useSsl`                        | true             | -                    | no  | Use of SSL/TLS to connect to the S3 server
+| `bucket-deletion`               | false            | -                    | no  | Trigger bucket deletion on the S3 backend upon CR deletion (:warning: implies data loss)
+| `policy-deletion`               | false            | -                    | no  | Trigger policy deletion on the S3 backend upon CR deletion
+| `path-deletion`                 | false            | -                    | no  | Trigger path deletion on the S3 backend upon CR deletion (:warning: implies data loss)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ The parameters are summarized in the table below :
 | `s3-provider`                   | `minio`          | -                    | no  | S3 provider (possible values : `minio`, `mockedS3Provider`)
 | `s3-secret-key`                 | -                | `S3_SECRET_KEY`      | no  | The secret key used to interact with  the S3 server.
 | `useSsl`                        | true             | -                    | no  | Use of SSL/TLS to connect to the S3 server
-| `bucket-deletion`               | false            | -                    | no  | Trigger bucket deletion on the S3 backend upon CR deletion (:warning: implies data loss)
+| `bucket-deletion`               | false            | -                    | no  | Trigger bucket deletion on the S3 backend upon CR deletion. Will fail if bucket is not empty.
 | `policy-deletion`               | false            | -                    | no  | Trigger policy deletion on the S3 backend upon CR deletion
-| `path-deletion`                 | false            | -                    | no  | Trigger path deletion on the S3 backend upon CR deletion (:warning: implies data loss)
+| `path-deletion`                 | false            | -                    | no  | Trigger path deletion on the S3 backend upon CR deletion. Limited to deleting the `.keep` files used by the operator.
 
 
 ## Usage

--- a/api/v1alpha1/path_types.go
+++ b/api/v1alpha1/path_types.go
@@ -39,7 +39,7 @@ type PathSpec struct {
 
 // PathStatus defines the observed state of Path
 type PathStatus struct {
-	// Status management using Conditions. 
+	// Status management using Conditions.
 	// See also : https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -29,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -49,28 +49,76 @@ type BucketReconciler struct {
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=buckets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=buckets/finalizers,verbs=update
 
+const bucketFinalizer = "s3.onyxia.sh/finalizer"
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
+	errorLogger := log.FromContext(ctx)
+	logger := ctrl.Log.WithName("bucketReconcile")
 
+	// Checking for bucket resource existence
 	bucketResource := &s3v1alpha1.Bucket{}
 	err := r.Get(ctx, req.NamespacedName, bucketResource)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			logger.Info(fmt.Sprintf("Bucket CRD %s has been removed. NOOP", req.Name))
+			logger.Info("The Bucket custom resource has been removed ; as such the Bucket controller is NOOP.", "req.Name", req.Name)
 			return ctrl.Result{}, nil
 		}
+		errorLogger.Error(err, "An error occurred when attempting to read the Bucket resource from the Kubernetes cluster")
 		return ctrl.Result{}, err
 	}
+
+	// Managing bucket deletion with a finalizer
+	// REF : https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#external-resources
+	isMarkedForDeletion := bucketResource.GetDeletionTimestamp() != nil
+	if isMarkedForDeletion {
+		if controllerutil.ContainsFinalizer(bucketResource, bucketFinalizer) {
+			// Run finalization logic for bucketFinalizer. If the
+			// finalization logic fails, don't remove the finalizer so
+			// that we can retry during the next reconciliation.
+			if err := r.finalizeBucket(bucketResource); err != nil {
+				// return ctrl.Result{}, err
+				errorLogger.Error(err, "an error occurred when attempting to finalize the bucket", "bucket", bucketResource.Spec.Name)
+				// return ctrl.Result{}, err
+				return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketFinalizeFailed",
+					fmt.Sprintf("An error occurred when attempting to delete bucket [%s]", bucketResource.Spec.Name), err)
+			}
+
+			// Remove bucketFinalizer. Once all finalizers have been
+			// removed, the object will be deleted.
+			controllerutil.RemoveFinalizer(bucketResource, bucketFinalizer)
+			err := r.Update(ctx, bucketResource)
+			if err != nil {
+				errorLogger.Error(err, "an error occurred when removing finalizer from bucket", "bucket", bucketResource.Spec.Name)
+				// return ctrl.Result{}, err
+				return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketFinalizerRemovalFailed",
+					fmt.Sprintf("An error occurred when attempting to remove the finalizer from bucket [%s]", bucketResource.Spec.Name), err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Add finalizer for this CR
+	if !controllerutil.ContainsFinalizer(bucketResource, bucketFinalizer) {
+		controllerutil.AddFinalizer(bucketResource, bucketFinalizer)
+		err = r.Update(ctx, bucketResource)
+		if err != nil {
+			errorLogger.Error(err, "an error occurred when adding finalizer from bucket", "bucket", bucketResource.Spec.Name)
+			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketFinalizerAddFailed",
+				fmt.Sprintf("An error occurred when attempting to add the finalizer from bucket [%s]", bucketResource.Spec.Name), err)
+		}
+	}
+
+	// Bucket lifecycle management (other than deletion) starts here
 
 	// Check bucket existence on the S3 server
 	found, err := r.S3Client.BucketExists(bucketResource.Spec.Name)
 	if err != nil {
-		logger.Error(err, "an error occurred while checking the existence of a bucket", "bucket", bucketResource.Spec.Name)
+		errorLogger.Error(err, "an error occurred while checking the existence of a bucket", "bucket", bucketResource.Spec.Name)
 		return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketExistenceCheckFailed",
 			fmt.Sprintf("Checking existence of bucket [%s] from S3 instance has failed", bucketResource.Spec.Name), err)
 	}
@@ -81,7 +129,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Bucket creation
 		err = r.S3Client.CreateBucket(bucketResource.Spec.Name)
 		if err != nil {
-			logger.Error(err, "an error occurred while creating a bucket", "bucket", bucketResource.Spec.Name)
+			errorLogger.Error(err, "an error occurred while creating a bucket", "bucket", bucketResource.Spec.Name)
 			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketCreationFailed",
 				fmt.Sprintf("Creation of bucket [%s] on S3 instance has failed", bucketResource.Spec.Name), err)
 		}
@@ -89,16 +137,16 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Setting quotas
 		err = r.S3Client.SetQuota(bucketResource.Spec.Name, bucketResource.Spec.Quota.Default)
 		if err != nil {
-			logger.Error(err, "an error occurred while setting a quota on a bucket", "bucket", bucketResource.Spec.Name, "quota", bucketResource.Spec.Quota.Default)
+			errorLogger.Error(err, "an error occurred while setting a quota on a bucket", "bucket", bucketResource.Spec.Name, "quota", bucketResource.Spec.Quota.Default)
 			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "SetQuotaOnBucketFailed",
 				fmt.Sprintf("Setting a quota of [%v] on bucket [%s] has failed", bucketResource.Spec.Quota.Default, bucketResource.Spec.Name), err)
 		}
 
-		// Création des chemins
+		// Path creation
 		for _, v := range bucketResource.Spec.Paths {
 			err = r.S3Client.CreatePath(bucketResource.Spec.Name, v)
 			if err != nil {
-				logger.Error(err, "an error occurred while creating a path on a bucket", "bucket", bucketResource.Spec.Name, "path", v)
+				errorLogger.Error(err, "an error occurred while creating a path on a bucket", "bucket", bucketResource.Spec.Name, "path", v)
 				return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "CreatingPathOnBucketFailed",
 					fmt.Sprintf("Creating the path [%s] on bucket [%s] has failed", v, bucketResource.Spec.Name), err)
 			}
@@ -115,7 +163,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Checking effectiveQuota existence on the bucket
 	effectiveQuota, err := r.S3Client.GetQuota(bucketResource.Spec.Name)
 	if err != nil {
-		logger.Error(err, "an error occurred while getting the quota for a bucket", "bucket", bucketResource.Spec.Name)
+		errorLogger.Error(err, "an error occurred while getting the quota for a bucket", "bucket", bucketResource.Spec.Name)
 		return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketQuotaCheckFailed",
 			fmt.Sprintf("The check for a quota on bucket [%s] has failed", bucketResource.Spec.Name), err)
 	}
@@ -132,7 +180,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if effectiveQuota != quotaToResetTo {
 		err = r.S3Client.SetQuota(bucketResource.Spec.Name, quotaToResetTo)
 		if err != nil {
-			logger.Error(err, "an error occurred while resetting the quota for a bucket", "bucket", bucketResource.Spec.Name, "quotaToResetTo", quotaToResetTo)
+			errorLogger.Error(err, "an error occurred while resetting the quota for a bucket", "bucket", bucketResource.Spec.Name, "quotaToResetTo", quotaToResetTo)
 			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketQuotaUpdateFailed",
 				fmt.Sprintf("The quota update (%v => %v) on bucket [%s] has failed", effectiveQuota, quotaToResetTo, bucketResource.Spec.Name), err)
 		}
@@ -148,7 +196,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	for _, pathInCr := range bucketResource.Spec.Paths {
 		pathExists, err := r.S3Client.PathExists(bucketResource.Spec.Name, pathInCr)
 		if err != nil {
-			logger.Error(err, "an error occurred while checking a path's existence on a bucket", "bucket", bucketResource.Spec.Name, "path", pathInCr)
+			errorLogger.Error(err, "an error occurred while checking a path's existence on a bucket", "bucket", bucketResource.Spec.Name, "path", pathInCr)
 			return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketPathCheckFailed",
 				fmt.Sprintf("The check for path [%s] on bucket [%s] has failed", pathInCr, bucketResource.Spec.Name), err)
 		}
@@ -156,7 +204,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if !pathExists {
 			err = r.S3Client.CreatePath(bucketResource.Spec.Name, pathInCr)
 			if err != nil {
-				logger.Error(err, "an error occurred while creating a path on a bucket", "bucket", bucketResource.Spec.Name, "path", pathInCr)
+				errorLogger.Error(err, "an error occurred while creating a path on a bucket", "bucket", bucketResource.Spec.Name, "path", pathInCr)
 				return r.SetBucketStatusConditionAndUpdate(ctx, bucketResource, "OperatorFailed", metav1.ConditionFalse, "BucketPathCreationFailed",
 					fmt.Sprintf("The creation of path [%s] on bucket [%s] has failed", pathInCr, bucketResource.Spec.Name), err)
 			}
@@ -171,17 +219,44 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 // SetupWithManager sets up the controller with the Manager.*
 func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	logger := ctrl.Log.WithName("bucketEventFilter")
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&s3v1alpha1.Bucket{}).
-		// TODO : implement a real strategy for event filtering ; for now just using the example from OpSDK doc
-		// (https://sdk.operatorframework.io/docs/building-operators/golang/references/event-filtering/)
+		// REF : https://sdk.operatorframework.io/docs/building-operators/golang/references/event-filtering/
 		WithEventFilter(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				// Ignore updates to CR status in which case metadata.Generation does not change
-				return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+				// Only reconcile if :
+				// - Generation has changed
+				//   or
+				// - Of all Conditions matching the last generation, none is in status "True"
+				// There is an implicit assumption that in such a case, the resource was once failing, but then transitioned
+				// to a functional state. We use this ersatz because lastTransitionTime appears to not work properly - see also
+				// comment in SetBucketStatusConditionAndUpdate() below.
+				newBucket, _ := e.ObjectNew.(*s3v1alpha1.Bucket)
+
+				// 1 - Identifying the most recent generation
+				var maxGeneration int64 = 0
+				for _, condition := range newBucket.Status.Conditions {
+					if condition.ObservedGeneration > maxGeneration {
+						maxGeneration = condition.ObservedGeneration
+					}
+				}
+				// 2 - Checking one of the conditions in most recent generation is True
+				conditionTrueInLastGeneration := false
+				for _, condition := range newBucket.Status.Conditions {
+					if condition.ObservedGeneration == maxGeneration && condition.Status == metav1.ConditionTrue {
+						conditionTrueInLastGeneration = true
+					}
+				}
+				predicate := e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() || !conditionTrueInLastGeneration
+				if !predicate {
+					logger.Info("reconcile update event is filtered out", "resource", e.ObjectNew.GetName())
+				}
+				return predicate
 			},
 			DeleteFunc: func(e event.DeleteEvent) bool {
 				// Evaluates to false if the object has been confirmed deleted.
+				logger.Info("reconcile delete event is filtered out", "resource", e.Object.GetName())
 				return !e.DeleteStateUnknown
 			},
 		}).
@@ -189,15 +264,33 @@ func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+func (r *BucketReconciler) finalizeBucket(bucketResource *s3v1alpha1.Bucket) error {
+	if r.BucketDeletion {
+		return r.S3Client.DeleteBucket(bucketResource.Spec.Name)
+	}
+	return nil
+}
+
 func (r *BucketReconciler) SetBucketStatusConditionAndUpdate(ctx context.Context, bucketResource *s3v1alpha1.Bucket, conditionType string, status metav1.ConditionStatus, reason string, message string, srcError error) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	// It would seem LastTransitionTime does not work as intended (our understanding of the intent coming from this :
+	// https://pkg.go.dev/k8s.io/apimachinery@v0.28.3/pkg/api/meta#SetStatusCondition). Whether we set the
+	// date manually or leave it out to have default behavior, the lastTransitionTime is NOT updated if the CR
+	// had that condition at least once in the past.
+	// For instance, with the following updates to a CR :
+	//	- gen 1 : condition type = A
+	//	- gen 2 : condition type = B
+	//	- gen 3 : condition type = A again
+	// Then the condition with type A in CR Status will still have the lastTransitionTime dating back to gen 1.
+	// Because of this, lastTransitionTime cannot be reliably used to determine current state, which in turn had
+	// us turn to a less than ideal event filter (see above in SetupWithManager())
 	meta.SetStatusCondition(&bucketResource.Status.Conditions,
 		metav1.Condition{
-			Type:               conditionType,
-			Status:             status,
-			Reason:             reason,
-			LastTransitionTime: metav1.NewTime(time.Now()),
+			Type:   conditionType,
+			Status: status,
+			Reason: reason,
+			// LastTransitionTime: metav1.NewTime(time.Now()),
 			Message:            message,
 			ObservedGeneration: bucketResource.GetGeneration(),
 		})

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -170,6 +171,7 @@ func (r *BucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 // SetupWithManager sets up the controller with the Manager.*
 func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	logger := ctrl.Log.WithName("setupWithManager")
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&s3v1alpha1.Bucket{}).
 		// TODO : implement a real strategy for event filtering ; for now just using the example from OpSDK doc
@@ -177,10 +179,13 @@ func (r *BucketReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				// Ignore updates to CR status in which case metadata.Generation does not change
+				logger.Info("Passage dans UpdateFunc ; is predicate true ? ")
+				logger.Info(strconv.FormatBool(e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()))
 				return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 			},
 			DeleteFunc: func(e event.DeleteEvent) bool {
 				// Evaluates to false if the object has been confirmed deleted.
+				logger.Info("Passage dans DeleteFunc")
 				return !e.DeleteStateUnknown
 			},
 		}).

--- a/controllers/bucket_controller.go
+++ b/controllers/bucket_controller.go
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	s3v1alpha1 "github.com/phlg/s3-operator-downgrade/api/v1alpha1"
-	"github.com/phlg/s3-operator-downgrade/controllers/s3/factory"
+	s3v1alpha1 "github.com/InseeFrLab/s3-operator/api/v1alpha1"
+	"github.com/InseeFrLab/s3-operator/controllers/s3/factory"
 )
 
 // BucketReconciler reconciles a Bucket object

--- a/controllers/path_controller.go
+++ b/controllers/path_controller.go
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	s3v1alpha1 "github.com/phlg/s3-operator-downgrade/api/v1alpha1"
-	"github.com/phlg/s3-operator-downgrade/controllers/s3/factory"
+	s3v1alpha1 "github.com/InseeFrLab/s3-operator/api/v1alpha1"
+	"github.com/InseeFrLab/s3-operator/controllers/s3/factory"
 )
 
 // PathReconciler reconciles a Path object

--- a/controllers/path_controller.go
+++ b/controllers/path_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -40,8 +39,9 @@ import (
 // PathReconciler reconciles a Path object
 type PathReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	S3Client factory.S3Client
+	Scheme       *runtime.Scheme
+	S3Client     factory.S3Client
+	PathDeletion bool
 }
 
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=paths,verbs=get;list;watch;create;update;patch;delete
@@ -50,10 +50,6 @@ type PathReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Path object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
@@ -119,37 +115,70 @@ func (r *PathReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PathReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	logger := ctrl.Log.WithName("eventFilter")
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&s3v1alpha1.Path{}).
-		// TODO : implement a real strategy for event filtering ; for now just using the example from OpSDK doc
-		// (https://sdk.operatorframework.io/docs/building-operators/golang/references/event-filtering/)
 		WithEventFilter(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				// Ignore updates to CR status in which case metadata.Generation does not change
-				return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+				// Only reconcile if :
+				// - Generation has changed
+				//   or
+				// - Of all Conditions matching the last generation, none is in status "True"
+				// There is an implicit assumption that in such a case, the resource was once failing, but then transitioned
+				// to a functional state. We use this ersatz because lastTransitionTime appears to not work properly - see also
+				// comment in SetPathStatusConditionAndUpdate() below.
+				newPath, _ := e.ObjectNew.(*s3v1alpha1.Path)
+
+				// 1 - Identifying the most recent generation
+				var maxGeneration int64 = 0
+				for _, condition := range newPath.Status.Conditions {
+					if condition.ObservedGeneration > maxGeneration {
+						maxGeneration = condition.ObservedGeneration
+					}
+				}
+				// 2 - Checking one of the conditions in most recent generation is True
+				conditionTrueInLastGeneration := false
+				for _, condition := range newPath.Status.Conditions {
+					if condition.ObservedGeneration == maxGeneration && condition.Status == metav1.ConditionTrue {
+						conditionTrueInLastGeneration = true
+					}
+				}
+				predicate := e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() || !conditionTrueInLastGeneration
+				if !predicate {
+					logger.Info("reconcile update event is filtered out", "resource", e.ObjectNew.GetName())
+				}
+				return predicate
 			},
 			DeleteFunc: func(e event.DeleteEvent) bool {
 				// Evaluates to false if the object has been confirmed deleted.
+				logger.Info("reconcile delete event is filtered out", "resource", e.Object.GetName())
 				return !e.DeleteStateUnknown
 			},
 		}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		Complete(r)
-
-	// return ctrl.NewControllerManagedBy(mgr).
-	// 	For(&s3v1alpha1.Path{}).
-	// 	Complete(r)
 }
 
 func (r *PathReconciler) SetPathStatusConditionAndUpdate(ctx context.Context, pathResource *s3v1alpha1.Path, conditionType string, status metav1.ConditionStatus, reason string, message string, srcError error) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	// It would seem LastTransitionTime does not work as intended (our understanding of the intent coming from this :
+	// https://pkg.go.dev/k8s.io/apimachinery@v0.28.3/pkg/api/meta#SetStatusCondition). Whether we set the
+	// date manually or leave it out to have default behavior, the lastTransitionTime is NOT updated if the CR
+	// had that condition at least once in the past.
+	// For instance, with the following updates to a CR :
+	//	- gen 1 : condition type = A
+	//	- gen 2 : condition type = B
+	//	- gen 3 : condition type = A again
+	// Then the condition with type A in CR Status will still have the lastTransitionTime dating back to gen 1.
+	// Because of this, lastTransitionTime cannot be reliably used to determine current state, which in turn had
+	// us turn to a less than ideal event filter (see above in SetupWithManager())
 	meta.SetStatusCondition(&pathResource.Status.Conditions,
 		metav1.Condition{
-			Type:               conditionType,
-			Status:             status,
-			Reason:             reason,
-			LastTransitionTime: metav1.NewTime(time.Now()),
+			Type:   conditionType,
+			Status: status,
+			Reason: reason,
+			// LastTransitionTime: metav1.NewTime(time.Now()),
 			Message:            message,
 			ObservedGeneration: pathResource.GetGeneration(),
 		})

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -43,13 +44,16 @@ import (
 // PolicyReconciler reconciles a Policy object
 type PolicyReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	S3Client factory.S3Client
+	Scheme         *runtime.Scheme
+	S3Client       factory.S3Client
+	PolicyDeletion bool
 }
 
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=policies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=policies/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=s3.onyxia.sh,resources=policies/finalizers,verbs=update
+
+const policyFinalizer = "s3.onyxia.sh/finalizer"
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -57,24 +61,74 @@ type PolicyReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
+	errorLogger := log.FromContext(ctx)
+	logger := ctrl.Log.WithName("reconcile")
 
+	// Checking for policy resource existence
 	policyResource := &s3v1alpha1.Policy{}
 	err := r.Get(ctx, req.NamespacedName, policyResource)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
 			logger.Info("The Policy CRD has been removed ; as such the Policy controller is NOOP.", "req.Name", req.Name)
 			return ctrl.Result{}, nil
 		}
+		errorLogger.Error(err, "An error occurred when attempting to read the Policy resource from the Kubernetes cluster")
 		return ctrl.Result{}, err
 	}
+
+	// Manging policy deletion, with a finalizer
+	// REF : https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#external-resources
+	isMarkedForDeletion := policyResource.GetDeletionTimestamp() != nil
+	if isMarkedForDeletion {
+		if controllerutil.ContainsFinalizer(policyResource, policyFinalizer) {
+			// Run finalization logic for policyFinalizer. If the
+			// finalization logic fails, don't remove the finalizer so
+			// that we can retry during the next reconciliation.
+			if err := r.finalizePolicy(policyResource); err != nil {
+				// return ctrl.Result{}, err
+				errorLogger.Error(err, "an error occurred when attempting to finalize the policy", "policy", policyResource.Spec.Name)
+				// return ctrl.Result{}, err
+				return r.SetPolicyStatusConditionAndUpdate(ctx, policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyFinalizeFailed",
+					fmt.Sprintf("An error occurred when attempting to delete policy [%s]", policyResource.Spec.Name), err)
+			}
+
+			// Remove policyFinalizer. Once all finalizers have been
+			// removed, the object will be deleted.
+			controllerutil.RemoveFinalizer(policyResource, policyFinalizer)
+			err := r.Update(ctx, policyResource)
+			if err != nil {
+				errorLogger.Error(err, "an error occurred when removing finalizer from policy", "policy", policyResource.Spec.Name)
+				// return ctrl.Result{}, err
+				return r.SetPolicyStatusConditionAndUpdate(ctx, policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyFinalizerRemovalFailed",
+					fmt.Sprintf("An error occurred when attempting to remove the finalizer from policy [%s]", policyResource.Spec.Name), err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Add finalizer for this CR
+	if !controllerutil.ContainsFinalizer(policyResource, policyFinalizer) {
+		controllerutil.AddFinalizer(policyResource, policyFinalizer)
+		err = r.Update(ctx, policyResource)
+		if err != nil {
+			errorLogger.Error(err, "an error occurred when adding finalizer from policy", "policy", policyResource.Spec.Name)
+			// return ctrl.Result{}, err
+			return r.SetPolicyStatusConditionAndUpdate(ctx, policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyFinalizerAddFailed",
+				fmt.Sprintf("An error occurred when attempting to add the finalizer from policy [%s]", policyResource.Spec.Name), err)
+		}
+	}
+
+	// Policy lifecycle management (other than deletion) starts here
 
 	// Check policy existence on the S3 server
 	effectivePolicy, err := r.S3Client.GetPolicyInfo(policyResource.Spec.Name)
 
 	// If the policy does not exist on S3...
 	if err != nil {
-		logger.Error(err, "an error occurred while checking the existence of a policy", "policy", policyResource.Spec.Name)
+		errorLogger.Error(err, "an error occurred while checking the existence of a policy", "policy", policyResource.Spec.Name)
 		return r.SetPolicyStatusConditionAndUpdate(ctx, policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyInfoFailed",
 			fmt.Sprintf("Obtaining policy[%s] info from S3 instance has failed", policyResource.Spec.Name), err)
 	}
@@ -84,7 +138,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Policy creation using info from the CR
 		err = r.S3Client.CreateOrUpdatePolicy(policyResource.Spec.Name, policyResource.Spec.PolicyContent)
 		if err != nil {
-			logger.Error(err, "an error occurred while creating the policy", "policy", policyResource.Spec.Name)
+			errorLogger.Error(err, "an error occurred while creating the policy", "policy", policyResource.Spec.Name)
 			return r.SetPolicyStatusConditionAndUpdate(ctx, policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyCreationFailed",
 				fmt.Sprintf("The creation of policy [%s] has failed", policyResource.Spec.Name), err)
 		}
@@ -98,7 +152,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// If the policy exists on S3, we compare its state to the custom resource that spawned it on K8S
 	matching, err := IsPolicyMatchingWithCustomResource(policyResource, effectivePolicy)
 	if err != nil {
-		logger.Error(err, "an error occurred while comparing actual and expected configuration for the policy", "policy", policyResource.Spec.Name)
+		errorLogger.Error(err, "an error occurred while comparing actual and expected configuration for the policy", "policy", policyResource.Spec.Name)
 		return r.SetPolicyStatusConditionAndUpdate(ctx, policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyComparisonFailed",
 			fmt.Sprintf("The comparison between the effective policy [%s] on S3 and its corresponding custom resource on K8S has failed", policyResource.Spec.Name), err)
 	}
@@ -112,7 +166,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// If not we update the policy to match the CR
 	err = r.S3Client.CreateOrUpdatePolicy(policyResource.Spec.Name, policyResource.Spec.PolicyContent)
 	if err != nil {
-		logger.Error(err, "an error occurred while updating the policy", "policy", policyResource.Spec.Name)
+		errorLogger.Error(err, "an error occurred while updating the policy", "policy", policyResource.Spec.Name)
 		return r.SetPolicyStatusConditionAndUpdate(ctx, policyResource, "OperatorFailed", metav1.ConditionFalse, "PolicyUpdateFailed",
 			fmt.Sprintf("The update of effective policy [%s] on S3 to match its corresponding custom resource on K8S has failed", policyResource.Spec.Name), err)
 	}
@@ -161,18 +215,6 @@ func IsPolicyMatchingWithCustomResource(policyResource *s3v1alpha1.Policy, effec
 	return bytes.Equal(buffer.Bytes(), marshalled), nil
 }
 
-// func SetPolicyStatusCondition(policyResource *s3v1alpha1.Policy, conditionType string, status metav1.ConditionStatus, reason string, message string) {
-// 	meta.SetStatusCondition(&policyResource.Status.Conditions,
-// 		metav1.Condition{
-// 			Type:               conditionType,
-// 			Status:             status,
-// 			Reason:             reason,
-// 			LastTransitionTime: metav1.NewTime(time.Now()),
-// 			Message:            message,
-// 			ObservedGeneration: policyResource.GetGeneration(),
-// 		})
-// }
-
 func (r *PolicyReconciler) SetPolicyStatusConditionAndUpdate(ctx context.Context, policyResource *s3v1alpha1.Policy, conditionType string, status metav1.ConditionStatus, reason string, message string, srcError error) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -192,4 +234,13 @@ func (r *PolicyReconciler) SetPolicyStatusConditionAndUpdate(ctx context.Context
 		return ctrl.Result{}, utilerrors.NewAggregate([]error{err, srcError})
 	}
 	return ctrl.Result{}, srcError
+}
+
+func (r *PolicyReconciler) finalizePolicy(policyResource *s3v1alpha1.Policy) error {
+
+	if r.PolicyDeletion {
+		return r.S3Client.DeletePolicy(policyResource.Spec.Name)
+	}
+
+	return nil
 }

--- a/controllers/policy_controller.go
+++ b/controllers/policy_controller.go
@@ -36,8 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	s3v1alpha1 "github.com/phlg/s3-operator-downgrade/api/v1alpha1"
-	"github.com/phlg/s3-operator-downgrade/controllers/s3/factory"
+	s3v1alpha1 "github.com/InseeFrLab/s3-operator/api/v1alpha1"
+	"github.com/InseeFrLab/s3-operator/controllers/s3/factory"
 )
 
 // PolicyReconciler reconciles a Policy object

--- a/controllers/s3/factory/interface.go
+++ b/controllers/s3/factory/interface.go
@@ -18,12 +18,14 @@ type S3Client interface {
 	DeleteBucket(name string) error
 	CreatePath(bucketname string, path string) error
 	PathExists(bucketname string, path string) (bool, error)
+	DeletePath(bucketname string, path string) error
 	GetQuota(name string) (int64, error)
 	SetQuota(name string, quota int64) error
 	// see comment in [minioS3Client.go] regarding the absence of a PolicyExists method
 	// PolicyExists(name string) (bool, error)
 	GetPolicyInfo(name string) (*madmin.PolicyInfo, error)
 	CreateOrUpdatePolicy(name string, content string) error
+	DeletePolicy(name string) error
 }
 
 type S3Config struct {

--- a/controllers/s3/factory/minioS3Client.go
+++ b/controllers/s3/factory/minioS3Client.go
@@ -152,6 +152,16 @@ func (minioS3Client *MinioS3Client) PathExists(bucketname string, path string) (
 	return true, nil
 }
 
+func (minioS3Client *MinioS3Client) DeletePath(bucketname string, path string) error {
+	s3Logger.Info("deleting a path on a bucket", "bucket", bucketname, "path", path)
+	err := minioS3Client.client.RemoveObject(context.Background(), bucketname, "/"+path+"/.keep", minio.RemoveObjectOptions{ForceDelete: true})
+	if err != nil {
+		s3Logger.Error(err, "an error occurred during path creation on bucket", "bucket", bucketname, "path", path)
+		return err
+	}
+	return nil
+}
+
 // /////////////////
 // Quota methods //
 // /////////////////
@@ -212,4 +222,9 @@ func (minioS3Client *MinioS3Client) GetPolicyInfo(name string) (*madmin.PolicyIn
 func (minioS3Client *MinioS3Client) CreateOrUpdatePolicy(name string, content string) error {
 	s3Logger.Info("create or update policy", "policy", name)
 	return minioS3Client.adminClient.AddCannedPolicy(context.Background(), name, []byte(content))
+}
+
+func (minioS3Client *MinioS3Client) DeletePolicy(name string) error {
+	s3Logger.Info("delete policy", "policy", name)
+	return minioS3Client.adminClient.RemoveCannedPolicy(context.Background(), name)
 }

--- a/controllers/s3/factory/minioS3Client.go
+++ b/controllers/s3/factory/minioS3Client.go
@@ -114,6 +114,7 @@ func (minioS3Client *MinioS3Client) CreateBucket(name string) error {
 	return minioS3Client.client.MakeBucket(context.Background(), name, minio.MakeBucketOptions{Region: minioS3Client.s3Config.Region})
 }
 
+// Will fail if bucket is not empty
 func (minioS3Client *MinioS3Client) DeleteBucket(name string) error {
 	s3Logger.Info("deleting bucket", "bucket", name)
 	return minioS3Client.client.RemoveBucket(context.Background(), name)
@@ -154,9 +155,9 @@ func (minioS3Client *MinioS3Client) PathExists(bucketname string, path string) (
 
 func (minioS3Client *MinioS3Client) DeletePath(bucketname string, path string) error {
 	s3Logger.Info("deleting a path on a bucket", "bucket", bucketname, "path", path)
-	err := minioS3Client.client.RemoveObject(context.Background(), bucketname, "/"+path+"/.keep", minio.RemoveObjectOptions{ForceDelete: true})
+	err := minioS3Client.client.RemoveObject(context.Background(), bucketname, "/"+path+"/.keep", minio.RemoveObjectOptions{})
 	if err != nil {
-		s3Logger.Error(err, "an error occurred during path creation on bucket", "bucket", bucketname, "path", path)
+		s3Logger.Error(err, "an error occurred during path deletion on bucket", "bucket", bucketname, "path", path)
 		return err
 	}
 	return nil

--- a/controllers/s3/factory/mockedS3Client.go
+++ b/controllers/s3/factory/mockedS3Client.go
@@ -31,6 +31,11 @@ func (mockedS3Provider *MockedS3Client) PathExists(bucketname string, path strin
 	return true, nil
 }
 
+func (mockedS3Provider *MockedS3Client) DeletePath(bucketname string, path string) error {
+	s3Logger.Info("deleting a path on a bucket", "bucket", bucketname, "path", path)
+	return nil
+}
+
 func (mockedS3Provider *MockedS3Client) GetQuota(name string) (int64, error) {
 	s3Logger.Info("getting quota on bucket", "bucket", name)
 	return 1, nil
@@ -48,6 +53,11 @@ func (mockedS3Provider *MockedS3Client) GetPolicyInfo(name string) (*madmin.Poli
 
 func (mockedS3Provider *MockedS3Client) CreateOrUpdatePolicy(name string, content string) error {
 	s3Logger.Info("create or update policy", "policy", name, "policyContent", content)
+	return nil
+}
+
+func (mockedS3Provider *MockedS3Client) DeletePolicy(name string) error {
+	s3Logger.Info("delete policy", "policy", name)
 	return nil
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	s3onyxiashv1alpha1 "github.com/phlg/s3-operator-downgrade/api/v1alpha1"
+	s3onyxiashv1alpha1 "github.com/InseeFrLab/s3-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/phlg/s3-operator-downgrade
+module github.com/InseeFrLab/s3-operator
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -33,6 +34,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -108,6 +110,7 @@ func main() {
 	var serverOption = server.Options{
 		BindAddress: metricsAddr,
 	}
+	syncPeriod, _ := time.ParseDuration("5m")
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
 		Metrics: serverOption,
@@ -116,6 +119,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "1402b7b1.onyxia.sh",
+		Cache:                  cache.Options{SyncPeriod: &syncPeriod},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/main.go
+++ b/main.go
@@ -26,9 +26,9 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	s3v1alpha1 "github.com/phlg/s3-operator-downgrade/api/v1alpha1"
-	controllers "github.com/phlg/s3-operator-downgrade/controllers"
-	"github.com/phlg/s3-operator-downgrade/controllers/s3/factory"
+	s3v1alpha1 "github.com/InseeFrLab/s3-operator/api/v1alpha1"
+	controllers "github.com/InseeFrLab/s3-operator/controllers"
+	"github.com/InseeFrLab/s3-operator/controllers/s3/factory"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -34,7 +33,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -80,6 +78,9 @@ func main() {
 	var useSsl bool
 	var caCertificatesBase64 ArrayFlags
 	var caCertificatesBundlePath string
+	var bucketDeletion bool
+	var policyDeletion bool
+	var pathDeletion bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -96,6 +97,9 @@ func main() {
 	flag.StringVar(&caCertificatesBundlePath, "s3-ca-certificate-bundle-path", "", "(Optional) Path to a CA certificate file, for https requests to S3")
 	flag.StringVar(&region, "region", "us-east-1", "The region to configure for the S3 client")
 	flag.BoolVar(&useSsl, "useSsl", true, "Use of SSL/TLS to connect to the S3 endpoint")
+	flag.BoolVar(&bucketDeletion, "bucket-deletion", false, "Trigger bucket deletion on the S3 backend upon CR deletion (:warning: implies data loss)")
+	flag.BoolVar(&policyDeletion, "policy-deletion", false, "Trigger policy deletion on the S3 backend upon CR deletion")
+	flag.BoolVar(&pathDeletion, "path-deletion", false, "Trigger path deletion on the S3 backend upon CR deletion (:warning: implies data loss)")
 
 	opts := zap.Options{
 		Development: true,
@@ -110,7 +114,7 @@ func main() {
 	var serverOption = server.Options{
 		BindAddress: metricsAddr,
 	}
-	syncPeriod, _ := time.ParseDuration("5m")
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:  scheme,
 		Metrics: serverOption,
@@ -119,7 +123,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "1402b7b1.onyxia.sh",
-		Cache:                  cache.Options{SyncPeriod: &syncPeriod},
+		// To change the sync period, it's possible to use cache.Options()
+		// Caveat : the actual period is slightly longer than what configured,
+		// possibly because of cache expiration not accounted for ?
+		// Cache:                  cache.Options{SyncPeriod: 2 * time.Minute},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -160,25 +167,28 @@ func main() {
 	}
 
 	if err = (&controllers.BucketReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		S3Client: s3Client,
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		S3Client:       s3Client,
+		BucketDeletion: bucketDeletion,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bucket")
 		os.Exit(1)
 	}
 	if err = (&controllers.PathReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		S3Client: s3Client,
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		S3Client:     s3Client,
+		PathDeletion: pathDeletion,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Path")
 		os.Exit(1)
 	}
 	if err = (&controllers.PolicyReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		S3Client: s3Client,
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		S3Client:       s3Client,
+		PolicyDeletion: policyDeletion,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Policy")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -97,9 +97,9 @@ func main() {
 	flag.StringVar(&caCertificatesBundlePath, "s3-ca-certificate-bundle-path", "", "(Optional) Path to a CA certificate file, for https requests to S3")
 	flag.StringVar(&region, "region", "us-east-1", "The region to configure for the S3 client")
 	flag.BoolVar(&useSsl, "useSsl", true, "Use of SSL/TLS to connect to the S3 endpoint")
-	flag.BoolVar(&bucketDeletion, "bucket-deletion", false, "Trigger bucket deletion on the S3 backend upon CR deletion (:warning: implies data loss)")
+	flag.BoolVar(&bucketDeletion, "bucket-deletion", false, "Trigger bucket deletion on the S3 backend upon CR deletion. Will fail if bucket is not empty.")
 	flag.BoolVar(&policyDeletion, "policy-deletion", false, "Trigger policy deletion on the S3 backend upon CR deletion")
-	flag.BoolVar(&pathDeletion, "path-deletion", false, "Trigger path deletion on the S3 backend upon CR deletion (:warning: implies data loss)")
+	flag.BoolVar(&pathDeletion, "path-deletion", false, "Trigger path deletion on the S3 backend upon CR deletion. Limited to deleting the `.keep` files used by the operator.")
 
 	opts := zap.Options{
 		Development: true,


### PR DESCRIPTION
- Adds three flags to toggle resource deletion on the S3 backend. Caveats : 
  - Bucket deletion will fail if not empty
  - Path deletion only removes the `.keep` file, not everything matching the path as a prefix
  - The account used to run the operator must have the necessary rights (`s3:DeleteBucket`, `s3:DeleteObject`, `admin:DeletePolicy`)
- Changes the event filtering logic, see comments in any of the controller for details
- Fix the imports incorrectly referencing a fork under my personal GH namespace