### PR TITLE
fix: Infinite loop if user has been created without ListBucket permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,22 @@ spec:
   # Content of the policy, as a multiline string 
   # This should be IAM compliant JSON - follow the guidelines of the actual
   # S3 provider you're using, as sometimes only a subset is available.
+  # The first Statement (Allow ListBucket) should be applied to every user,
+  # as s3-operator uses this call to verify that credentials are valid when
+  # reconciling an existing user.
   policyContent: >-
     {
       "Version": "2012-10-17",
       "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "s3:ListBucket"
+        ],
+        "Resource": [
+          "arn:aws:s3:::*"
+        ]
+      },
       {
         "Effect": "Allow",
         "Action": [


### PR DESCRIPTION
As described in [this issue](https://github.com/InseeFrLab/s3-operator/issues/51), if a user has been created by s3-operator without a policy allowing ListBucket (either because no such policy was attached, or because s3-operator has not yet created the policy and cannot attach it), then the credentialsValid() function fails, and s3-operator assumes the credentials are wrong and exits, only to fail again at the next run (infinite loop).

The merge request moves the credentialsValid() function after the policy attachment, which allows s3-operator to attach a policy to an existing user that does not yet have the ListBucket permission. It also specifies the ListBucket permission in the README.