### PR TITLE
Add the capability to read existing secret for an S3User

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,6 +80,7 @@ func main() {
 
 	//K8S related variable
 	var overrideExistingSecret bool
+	var readExistingSecret bool
 
 	flag.StringVar(
 		&metricsAddr,
@@ -105,6 +106,12 @@ func main() {
 		"override-existing-secret",
 		false,
 		"Override existing secret associated to user in case of the secret already exist",
+	)
+	flag.BoolVar(
+		&readExistingSecret,
+		"read-existing-secret",
+		false,
+		"Read existing secret associated to user in case of the secret already exist",
 	)
 
 	opts := zap.Options{
@@ -203,6 +210,7 @@ func main() {
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
 		OverrideExistingSecret:  overrideExistingSecret,
+		ReadExistingSecret:  	 readExistingSecret,
 		ReconcilePeriod:         reconcilePeriod,
 		S3factory:               s3Factory,
 		ControllerHelper:        controllerHelper,

--- a/deploy/charts/s3-operator/README.md
+++ b/deploy/charts/s3-operator/README.md
@@ -24,6 +24,6 @@ A Helm chart for deploying an operator to manage S3 resources (eg buckets, polic
 | crds.install | bool | `true` | Install and upgrade CRDs |
 | crds.keep | bool | `true` | Keep CRDs on chart uninstall |
 | kubernetes.clusterDomain | string | `"cluster.local"` |  |
-| kubernetes.overrideExistingSecret | bool | `false` |  |
+| kubernetes.overrideExistingSecret | bool | `false` | When creating an S3User, update existing secret with the generated secret key |
+| kubernetes.readExistingSecret | bool | `false` | When creating an S3User, read existing secret to retrieve the secret key |
 | s3 | object | `{"default":{"accessKey":"accessKey","createNamespace":true,"deletion":{"bucket":true,"path":false,"policy":false,"s3user":false},"enabled":false,"namespace":"s3-operator","region":"us-east-1","s3Provider":"minio","secretKey":"secretKey","url":"https://localhost:9000"}}` | Default S3 Instance |
-

--- a/deploy/charts/s3-operator/templates/deployment.yaml
+++ b/deploy/charts/s3-operator/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --override-existing-secret={{ .Values.kubernetes.overrideExistingSecret }}
+        - --read-existing-secret={{ .Values.kubernetes.readExistingSecret }}
         {{- if .Values.controllerManager.manager.extraArgs }}
         {{- toYaml .Values.controllerManager.manager.extraArgs | nindent 8 }}
         {{- end }}

--- a/deploy/charts/s3-operator/values.yaml
+++ b/deploy/charts/s3-operator/values.yaml
@@ -48,6 +48,7 @@ controllerManager:
 kubernetes:
   clusterDomain: cluster.local
   overrideExistingSecret: false
+  readExistingSecret: false
 
 # -- Default S3 Instance
 s3:

--- a/internal/controller/user/controller.go
+++ b/internal/controller/user/controller.go
@@ -44,6 +44,7 @@ type S3UserReconciler struct {
 	client.Client
 	Scheme                  *runtime.Scheme
 	OverrideExistingSecret  bool
+	ReadExistingSecret      bool
 	ReconcilePeriod         time.Duration
 	S3factory               s3factory.S3Factory
 	ControllerHelper        *helpers.ControllerHelper


### PR DESCRIPTION
The goal of this PR is to be able to manage the secret key for an S3 User outside of the S3 Operator.
A new switch (`--read-existing-secret`) is introduced in the command line to make the S3 Operator read the secret key from an Kubernetes Secret instead of generating the secret and creation/updating the Kubernetes Secret.
