### PR TITLE
Avoid double slash in path

### DIFF
--- a/internal/s3/client/impl/minioS3Client.go
+++ b/internal/s3/client/impl/minioS3Client.go
@@ -252,7 +252,7 @@ func (minioS3Client *MinioS3Client) PathExists(bucketname string, path string) (
 	_, err := minioS3Client.client.
 		StatObject(context.Background(),
 			bucketname,
-			"/"+path+"/"+".keep",
+			path+"/"+".keep",
 			minio.StatObjectOptions{})
 	if err != nil {
 		if minio.ToErrorResponse(err).StatusCode == 404 {


### PR DESCRIPTION
StatObject already adds a slah between bucket name and object path.

When traefik is used and [path sanitization](https://doc.traefik.io/traefik/master/security/request-path/#3-path-sanitization) is enabled (the default), we get the following error:

> The check for path [a_path] in bucket has failed: The request signature
> we calculated does not match the signature you provided. Check your key
> and signing method.

This PR fixes this.